### PR TITLE
Fixed sidebar header on flatpages, moved CSS to static folder

### DIFF
--- a/chemie/chemie/static/css/flatpage.css
+++ b/chemie/chemie/static/css/flatpage.css
@@ -1,0 +1,17 @@
+heading {
+    padding-top: 2.0rem;
+    }
+
+@media only screen and (min-width: 960px) {
+    .flow-text {
+        font-size: 1.48rem;
+        }
+    }
+
+main, a {
+    white-space: nowrap
+    }
+
+    .indented {
+        padding-left: 15px !important;
+    }

--- a/chemie/chemie/templates/flatpages/default.html
+++ b/chemie/chemie/templates/flatpages/default.html
@@ -1,24 +1,9 @@
 {% extends "chemie/base.html" %}
+{% load staticfiles %}
 
 {% block header %}
   <style>
-    #heading {
-      padding-top: 2.0rem;
-    }
-
-    @media only screen and (min-width: 960px) {
-        .flow-text {
-            font-size: 1.48rem;
-        }
-    }
-
-    a {
-        white-space: nowrap
-    }
-
-    .indented {
-        padding-left: 15px !important;
-    }
+      {% static "css/flatpage.css" %}
   </style>
 {% endblock %}
 


### PR DESCRIPTION
Torbjørn har fiksa #84 . Han har samtidig flytta CSS fra templaten til en egen .css-fil i static-dir i appen. 