### PR TITLE
Fixed non-aligned attendees list and cleaned up css

### DIFF
--- a/chemie/events/templates/events/social/detail.html
+++ b/chemie/events/templates/events/social/detail.html
@@ -141,16 +141,16 @@
     </div>
 
     <!-- Payment info -->
-      {% if social.price_member or social.price_companion or social.price_companion %}
-    <div class="col s12 m12 l12">
-      <div class="card">
-        <div class="card-content">
-          <h5>Betalingsinformasjon:</h5>
-          <p class="flow-text"> {{ social.payment_information|linebreaksbr }} </p>
+    {% if social.price_member or social.price_companion or social.price_companion %}
+      <div class="col s12 m12 l12">
+        <div class="card">
+          <div class="card-content">
+            <h5>Betalingsinformasjon:</h5>
+            <p class="flow-text"> {{ social.payment_information|linebreaksbr }} </p>
+          </div>
         </div>
       </div>
-        {% endif %}
-    </div>
+    {% endif %}
   </div>
 
   <div class="row">


### PR DESCRIPTION
`</div>` was misplaced outside Django if-statement, which ended up closing earlier container, making the attendee list misaligned on free events.