### PR TITLE
Fix django admin header text

### DIFF
--- a/chemie/elections/admin.py
+++ b/chemie/elections/admin.py
@@ -2,7 +2,6 @@ from django.contrib import admin
 
 from .models import Candidate, Position, Election, Ticket
 
-admin.site.site_header = "Valg"
 admin.site.site_title = "Valg"
 
 


### PR DESCRIPTION
The Django admin header text now says "Django-administrasjon" instead of "Valg".